### PR TITLE
update the mapstore to ensure that additional queries from firing when a graphic clears

### DIFF
--- a/src/map/js/components/AnalysisPanel/SubscriptionTab.js
+++ b/src/map/js/components/AnalysisPanel/SubscriptionTab.js
@@ -336,8 +336,6 @@ export default class SubscriptionTab extends React.Component {
     layerActions.changeUserUploadedGeometry(null);
     modalActions.removeCustomFeature(app.map.graphics.graphics);
     this.setState({ showDrawnMapGraphics: false, drawnMapGraphics: false });
-
-    this.setState({ showDrawnMapGraphics: false });
   };
 
   //- DnD Functions

--- a/src/map/js/components/AnalysisPanel/SubscriptionTab.js
+++ b/src/map/js/components/AnalysisPanel/SubscriptionTab.js
@@ -335,7 +335,7 @@ export default class SubscriptionTab extends React.Component {
     // Update the mapstore graphic and drawnMapGraphics properties.
     layerActions.changeUserUploadedGeometry(null);
     modalActions.removeCustomFeature(app.map.graphics.graphics);
-    this.setState({ showDrawnMapGraphics: false, drawnMapGraphics: false });
+    this.setState({ showDrawnMapGraphics: false });
   };
 
   //- DnD Functions

--- a/src/map/js/components/AnalysisPanel/SubscriptionTab.js
+++ b/src/map/js/components/AnalysisPanel/SubscriptionTab.js
@@ -57,7 +57,7 @@ export default class SubscriptionTab extends React.Component {
       viirsEndDate: mapStore.getState().archiveViirsEndDate,
       modisStartDate: mapStore.getState().archiveModisStartDate,
       modisEndDate: mapStore.getState().archiveModisEndDate,
-      showDrawnMapGraphics: mapStore.getState().showDrawnMapGraphics
+      showDrawnMapGraphics: false
     };
   }
 

--- a/src/map/js/components/AnalysisPanel/SubscriptionTab.js
+++ b/src/map/js/components/AnalysisPanel/SubscriptionTab.js
@@ -282,7 +282,6 @@ export default class SubscriptionTab extends React.Component {
     if (state.geometryOfDrawnShape !== this.state.geometryOfDrawnShape) {
       this.setState({ geometryOfDrawnShape: state.geometryOfDrawnShape});
     }
-
   }
 
   componentWillReceiveProps() {

--- a/src/map/js/components/AnalysisPanel/SubscriptionTab.js
+++ b/src/map/js/components/AnalysisPanel/SubscriptionTab.js
@@ -272,11 +272,11 @@ export default class SubscriptionTab extends React.Component {
     if (state.drawnMapGraphics !== this.state.showDrawnMapGraphics) {
       this.setState({ showDrawnMapGraphics: state.drawnMapGraphics });
     }
-
     // Update the geometry if it has changed
     if (state.geometryOfDrawnShape !== this.state.geometryOfDrawnShape) {
-    this.setState({ geometryOfDrawnShape: state.geometryOfDrawnShape});
+      this.setState({ geometryOfDrawnShape: state.geometryOfDrawnShape});
     }
+
   }
 
   componentWillReceiveProps() {
@@ -324,8 +324,10 @@ export default class SubscriptionTab extends React.Component {
     if (app.map.graphics.graphics.length > 0) {
       app.map.graphics.clear();
     }
+    // Update the mapstore graphic and drawnMapGraphics properties.
     layerActions.changeUserUploadedGeometry(null);
-    this.setState({ showDrawnMapGraphics: false });
+    modalActions.removeCustomFeature(app.map.graphics.graphics);
+    this.setState({ showDrawnMapGraphics: false, drawnMapGraphics: false });
 
   };
 

--- a/src/map/js/stores/MapStore.js
+++ b/src/map/js/stores/MapStore.js
@@ -52,7 +52,6 @@ class MapStore {
     this.plantationSelectIndex = layerPanelText.plantationOptions.length - 1;
     this.forestSelectIndex = layerPanelText.forestOptions.length - 1;
     this.viirsSelectIndex = 0; //layerPanelText.firesOptions.length - 1; //0;
-    this.showDrawnMapGraphics = false;
     this.geometryOfDrawnShape = null;
     this.lossToSelectIndex = layerPanelText.lossOptions.length - 1;
     this.fireHistorySelectIndex = layerPanelText.fireHistoryOptions.length - 1;


### PR DESCRIPTION

Resolves the 5th item in [this ticket](https://blueraster.assembla.com/spaces/2278-wri-gfw-fires/tickets/435-bugs-when-adding-uploading-shape-for-analysis/details)