### PR TITLE
Fixed the query being sent out on load of the Punjab, Pakistan subregion.

### DIFF
--- a/src/report/js/ReportBuilder.js
+++ b/src/report/js/ReportBuilder.js
@@ -149,18 +149,14 @@ define([
               let url;
 
               if (window.reportOptions.aoiId) {
-                console.log('here', window.reportOptions.aoiId);
                 url = Config.fires_api_endpoint + 'admin/' + queryFor + '/' + window.reportOptions.aoiId + '?period=' + self.startDateRaw + ',' + self.endDateRaw;
               } else {
                 url = Config.fires_api_endpoint + 'admin/' + queryFor + '/' + '?period=' + self.startDateRaw + ',' + self.endDateRaw;
               }
 
-              console.log('url', url);
-              debugger;
               request.get(url, {
                 handleAs: 'json'
               }).then(function(response) {
-                console.log('here', response);
                 Promise.all(Config.countryPieCharts.map(function(chartConfig) {
                   return self.createPieChart(response.data.attributes.value[0].alerts, chartConfig);
                 })).then(() => {

--- a/src/report/js/ReportBuilder.js
+++ b/src/report/js/ReportBuilder.js
@@ -149,15 +149,18 @@ define([
               let url;
 
               if (window.reportOptions.aoiId) {
+                console.log('here', window.reportOptions.aoiId);
                 url = Config.fires_api_endpoint + 'admin/' + queryFor + '/' + window.reportOptions.aoiId + '?period=' + self.startDateRaw + ',' + self.endDateRaw;
               } else {
                 url = Config.fires_api_endpoint + 'admin/' + queryFor + '/' + '?period=' + self.startDateRaw + ',' + self.endDateRaw;
               }
 
+              console.log('url', url);
+              debugger;
               request.get(url, {
                 handleAs: 'json'
               }).then(function(response) {
-
+                console.log('here', response);
                 Promise.all(Config.countryPieCharts.map(function(chartConfig) {
                   return self.createPieChart(response.data.attributes.value[0].alerts, chartConfig);
                 })).then(() => {
@@ -180,7 +183,7 @@ define([
           query.returnGeometry = false;
 
           if (window.reportOptions.aois) {
-            query.where = `NAME_1 = '${window.reportOptions.aois}'`;
+            query.where = `NAME_0 = '${window.reportOptions.country}' AND NAME_1 = '${window.reportOptions.aois}'`;
             query.returnGeometry = false;
             query.outFields = ['id_1'];
 


### PR DESCRIPTION
The issue was that there were two subregions named Punjab: one in India and one in Pakistan. The results were sorted alphabetically by country name, and the first one was always being used. This commit adds an extra parameter into the query to query for subregions and country names, to ensure a more precise result.

To confirm that we did not break any other regions, we ran a query on the mapservice https://gis-gfw.wri.org/arcgis/rest/services/admin/MapServer/5 for distinct values of NAME_0 and noted no null or empty values.
